### PR TITLE
fix(WASIX): use advance_unchecked for TcpStream read_buf

### DIFF
--- a/library/std/src/sys/net/connection/wasix.rs
+++ b/library/std/src/sys/net/connection/wasix.rs
@@ -298,7 +298,7 @@ impl Socket {
             );
             match self.recv(slice) {
                 Ok(n) => {
-                    buf.advance(n);
+                    buf.advance_unchecked(n);
                     Ok(())
                 }
                 Err(e) => Err(e),


### PR DESCRIPTION
The recv already write into the buffer without first updating the cursor’s initialized-byte bookkeeping. Thus advance_unchecked must be used, otherwise we'll hit:
```
assertion failed: n <= self.buf.init - self.buf.filled
```