### PR TITLE
std: route libc to the WASIX fork via [patch.crates-io]

### DIFF
--- a/library/Cargo.lock
+++ b/library/Cargo.lock
@@ -83,7 +83,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06cdfe340b16dd990c54cce79743613fa09fbb16774f33a77c9fd196f8f3fa30"
 dependencies = [
  "cfg-if",
- "libc 0.2.183 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
  "rustc-std-workspace-core",
  "windows-sys",
 ]
@@ -147,15 +147,6 @@ dependencies = [
 [[package]]
 name = "libc"
 version = "0.2.183"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
-dependencies = [
- "rustc-std-workspace-core",
-]
-
-[[package]]
-name = "libc"
-version = "0.2.183"
 source = "git+https://github.com/wasix-org/libc.git?branch=wasix-0.2.183#029fad92706216db3c0942229acff50af66e2933"
 dependencies = [
  "rustc-std-workspace-core",
@@ -207,7 +198,7 @@ name = "panic_abort"
 version = "0.0.0"
 dependencies = [
  "alloc",
- "libc 0.2.183 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
  "rustc-std-workspace-core",
 ]
 
@@ -216,7 +207,7 @@ name = "panic_unwind"
 version = "0.0.0"
 dependencies = [
  "alloc",
- "libc 0.2.183 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
  "rustc-std-workspace-core",
  "unwind",
 ]
@@ -338,7 +329,7 @@ dependencies = [
  "fortanix-sgx-abi",
  "hashbrown",
  "hermit-abi",
- "libc 0.2.183 (git+https://github.com/wasix-org/libc.git?branch=wasix-0.2.183)",
+ "libc",
  "miniz_oxide",
  "moto-rt",
  "object",
@@ -362,7 +353,7 @@ dependencies = [
 name = "std_detect"
 version = "0.1.5"
 dependencies = [
- "libc 0.2.183 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
  "rustc-std-workspace-alloc",
  "rustc-std-workspace-core",
 ]
@@ -383,7 +374,7 @@ version = "0.0.0"
 dependencies = [
  "core",
  "getopts",
- "libc 0.2.183 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
  "std",
 ]
 
@@ -391,7 +382,7 @@ dependencies = [
 name = "unwind"
 version = "0.0.0"
 dependencies = [
- "libc 0.2.183 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
  "rustc-std-workspace-core",
  "unwinding",
 ]

--- a/library/Cargo.toml
+++ b/library/Cargo.toml
@@ -88,3 +88,5 @@ rustc-std-workspace-std = { path = 'rustc-std-workspace-std' }
 # The wasix crate's `rustc-dep-of-std` feature depends on compiler_builtins
 # from crates.io; route it to the in-tree copy instead of the registry stub.
 compiler_builtins = { path = "compiler-builtins/compiler-builtins" }
+
+libc = { git = "https://github.com/wasix-org/libc.git", branch = "wasix-0.2.183" }

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -33,7 +33,7 @@ miniz_oxide = { version = "0.8.0", optional = true, default-features = false }
 addr2line = { version = "0.25.0", optional = true, default-features = false }
 
 [target.'cfg(not(all(windows, target_env = "msvc")))'.dependencies]
-libc = { git = "https://github.com/wasix-org/libc.git", branch = "wasix-0.2.183", version = "0.2.183", default-features = false, features = [
+libc = { version = "0.2.183", default-features = false, features = [
     'rustc-dep-of-std',
 ], public = true }
 


### PR DESCRIPTION
std's direct git dependency left the rest of the library workspace (dlmalloc, panic_abort, panic_unwind, std_detect, test, unwind) on registry libc. Now that the wasix branch is ported to the exact version the workspace resolves (0.2.183), the lockfile carried the same name+version from two sources, which breaks name+version-keyed vendoring (e.g. nixpkgs importCargoLock), and wasix std linked crates built against two different libcs in one graph.