### PR TITLE
bootstrap: allow stdarch_wasm_atomic_wait for tools

### DIFF
--- a/src/bootstrap/src/core/builder/cargo.rs
+++ b/src/bootstrap/src/core/builder/cargo.rs
@@ -839,7 +839,7 @@ impl Builder<'_> {
                 // If this is ever removed, be sure to add something else in
                 // its place to keep the restrictions in place (or make a way
                 // to unset RUSTC_BOOTSTRAP).
-                "binary-dep-depinfo,proc_macro_span,proc_macro_span_shrink,proc_macro_diagnostic"
+                "binary-dep-depinfo,proc_macro_span,proc_macro_span_shrink,proc_macro_diagnostic,stdarch_wasm_atomic_wait"
                     .to_string()
             }
             Mode::Std | Mode::Rustc | Mode::Codegen | Mode::ToolRustcPrivate => String::new(),


### PR DESCRIPTION

Allow Rust bootstrap tools to use the internal `stdarch_wasm_atomic_wait`
feature. WASIX builds of Cargo's `wasm32-atomics` dependency require the
feature, but bootstrap currently strips it from the permitted tool feature
list.

Related Wasinix patch:
[tool-atomic-wait-feature.patch](https://github.com/wasix-org/wasinix/blob/main/pkgs/overlays/w/wasix-rust/tool-atomic-wait-feature.patch)

