### PR TITLE
target: declare WASIX wasm feature baseline

### DIFF
--- a/compiler/rustc_target/src/spec/targets/wasm32_wasmer_wasi.rs
+++ b/compiler/rustc_target/src/spec/targets/wasm32_wasmer_wasi.rs
@@ -141,8 +141,9 @@ pub(crate) fn target() -> Target {
     options.entry_name = "__main_void".into();
 
     // WASIX enables more WASM features
-    options.features =
-        "+bulk-memory,+atomics,+mutable-globals,+sign-ext,+nontrapping-fptoint".into();
+    options.features = "+bulk-memory,+atomics,+mutable-globals,+sign-ext,+nontrapping-fptoint,\
+                        +simd128,+relaxed-simd,+extended-const,+wide-arithmetic"
+        .into();
 
     Target {
         llvm_target: "wasm32-wasi".into(),


### PR DESCRIPTION

Declare the complete WASIX wasm feature baseline in the Rust target spec. This applies the features to every rustc entry point, including direct `cargo rustc` users such as maturin, and to the standard library build.

The `wasm32-wasmer-wasi-dl` target inherits the same baseline from `wasm32-wasmer-wasi`.

Related Wasinix patch:
[wasix-target-features.patch](https://github.com/wasix-org/wasinix/blob/rust-target-feature-baseline/pkgs/overlays/w/wasix-rust/wasix-target-features.patch)

Related Wasinix test:
[target-features.nix](https://github.com/wasix-org/wasinix/blob/rust-target-feature-baseline/pkgs/overlays/w/wasix-rust/tests/target-features.nix)

